### PR TITLE
HAproxy and Keepalived Service classes + additional fixes

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from ceph.deployment import inventory
 from ceph.deployment.drive_group import DriveGroupSpec
-from ceph.deployment.service_spec import ServiceSpec, HostPlacementSpec, RGWSpec
+from ceph.deployment.service_spec import ServiceSpec, HostPlacementSpec, RGWSpec, HA_RGWSpec
 
 import orchestrator
 from cephadm.schedule import HostAssignment
@@ -475,6 +475,9 @@ class CephadmServe:
         remove_daemon_hosts: Set[orchestrator.DaemonDescription] = ha.remove_daemon_hosts(hosts)
         self.log.debug('Hosts that will loose daemons: %s' % remove_daemon_hosts)
 
+        if daemon_type == 'HA_RGW':
+            spec = self.update_ha_rgw_definitive_hosts(spec, hosts, add_daemon_hosts)
+
         for host, network, name in add_daemon_hosts:
             daemon_id = self.mgr.get_unique_name(daemon_type, host, daemons,
                                                  prefix=spec.service_id,
@@ -496,13 +499,10 @@ class CephadmServe:
             try:
                 # HA_RGW needs to deploy 2 daemons
                 if daemon_type == 'HA_RGW':
-                    daemon_spec.daemon_type = 'haproxy'
-                    daemon_spec = self.mgr.cephadm_services['haproxy'].prepare_create(daemon_spec)
-                    self.mgr._create_daemon(daemon_spec)
-                    daemon_spec.daemon_type = 'keepalived'
-                    daemon_spec = self.mgr.cephadm_services['keepalived'].prepare_create(
-                        daemon_spec)
-                    self.mgr._create_daemon(daemon_spec)
+                    for dtype in ['haproxy', 'keepalived']:
+                        daemon_spec.daemon_type = dtype
+                        daemon_spec = self.mgr.cephadm_services[dtype].prepare_create(daemon_spec)
+                        self.mgr._create_daemon(daemon_spec)
                 else:
                     daemon_spec = self.mgr.cephadm_services[daemon_type].prepare_create(daemon_spec)
                     self.mgr._create_daemon(daemon_spec)
@@ -642,3 +642,19 @@ class CephadmServe:
                 image_info = digests[container_image_ref]
                 if image_info.repo_digest:
                     self.mgr.set_container_image(entity, image_info.repo_digest)
+
+    # HA_RGW needs definitve host list to create keepalived config files
+    # if definitive host list has changed, all HA_RGW daemons must get new
+    # config, including those that are already on the correct host and not
+    # going to be deployed
+    def update_ha_rgw_definitive_hosts(self, spec: ServiceSpec, hosts: List[HostPlacementSpec],
+                                       add_hosts: Set[HostPlacementSpec]) -> HA_RGWSpec:
+        spec = cast(HA_RGWSpec, spec)
+        if not (set(hosts) == set(spec.definitive_host_list)):
+            spec.definitive_host_list = hosts
+            ha_rgw_daemons = self.mgr.cache.get_daemons_by_service(spec.service_name())
+            for daemon in ha_rgw_daemons:
+                if daemon.hostname in [h.hostname for h in hosts] and daemon.hostname not in add_hosts:
+                    self.mgr.cache.schedule_daemon_action(
+                        daemon.hostname, daemon.name(), 'reconfig')
+        return spec

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -263,7 +263,7 @@ class CephService(CephadmService):
         """
         Map the daemon id to a cephx keyring entity name
         """
-        if self.TYPE in ['rgw', 'rbd-mirror', 'nfs', "iscsi"]:
+        if self.TYPE in ['rgw', 'rbd-mirror', 'nfs', "iscsi", 'haproxy', 'keepalived']:
             return AuthEntity(f'client.{self.TYPE}.{daemon_id}')
         elif self.TYPE == 'crash':
             if host == "":

--- a/src/pybind/mgr/cephadm/services/ha_rgw.py
+++ b/src/pybind/mgr/cephadm/services/ha_rgw.py
@@ -1,0 +1,82 @@
+import json
+import logging
+from typing import List, cast, Tuple
+
+from ceph.deployment.service_spec import HA_RGWSpec
+
+from orchestrator import DaemonDescription, OrchestratorError
+from .cephadmservice import CephadmDaemonSpec, CephService
+from .. import utils
+
+logger = logging.getLogger(__name__)
+
+
+class HA_RGWService(CephService):
+    TYPE = 'HA_RGW'
+
+class HAproxyService(CephService):
+    TYPE = 'haproxy'
+
+    class rgw_server():
+        def __init__(self, hostname: str, address: str):
+            self.name = hostname
+            self.ip = address
+
+    def prepare_create(self, daemon_spec: CephadmDaemonSpec[HA_RGWSpec]) -> CephadmDaemonSpec:
+        assert self.TYPE == daemon_spec.daemon_type
+        assert daemon_spec.spec
+
+        daemon_id = daemon_spec.daemon_id
+        host = daemon_spec.host
+        spec = daemon_spec.spec
+
+        rgw_daemons = self.mgr.cache.get_daemons_by_service('rgw')
+        rgw_servers = []
+        for daemon in rgw_daemons:
+            rgw_servers.append(self.rgw_server(daemon.hostname, self.mgr.inventory.get_addr(daemon.hostname)))
+
+        ha_context = {'spec': spec, 'rgw_servers': rgw_servers}
+
+        haproxy_conf = self.mgr.template.render('services/haproxy/haproxy.cfg.j2', ha_context)
+
+        daemon_spec.extra_files = {'haproxy.cfg': haproxy_conf}
+
+        ret, keyring, err = self.mgr.check_mon_command({
+            'prefix': 'auth get-or-create',
+            'entity': self.get_auth_entity(daemon_id),
+            'caps': [],
+        })
+
+        logger.info('Create daemon %s on host %s with spec %s' % (
+            daemon_id, host, spec))
+        return daemon_spec
+
+class KeepAlivedService(CephService):
+    TYPE = 'keepalived'
+
+    def prepare_create(self, daemon_spec: CephadmDaemonSpec[HA_RGWSpec]) -> CephadmDaemonSpec:
+        assert self.TYPE == daemon_spec.daemon_type
+        assert daemon_spec.spec
+
+        daemon_id = daemon_spec.daemon_id
+        host = daemon_spec.host
+        spec = daemon_spec.spec
+
+        ka_context = {'spec': spec, 'state': 'MASTER',
+                      'other_ips': [],
+                      'host_ip': self.mgr.inventory.get_addr(host)}
+
+        keepalive_conf = self.mgr.template.render(
+            'services/keepalived/keepalived.conf.j2', ka_context)
+
+        daemon_spec.extra_files = {'keepalived.conf': keepalive_conf}
+
+        ret, keyring, err = self.mgr.check_mon_command({
+            'prefix': 'auth get-or-create',
+            'entity': self.get_auth_entity(daemon_id),
+            'caps': [],
+        })
+
+        logger.info('Create daemon %s on host %s with spec %s' % (
+            daemon_id, host, spec))
+        return daemon_spec

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -6,6 +6,8 @@ import json
 
 import pytest
 
+import yaml
+
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, \
     IscsiServiceSpec, AlertManagerSpec, HostPlacementSpec, CustomContainerSpec, \
     HA_RGWSpec
@@ -636,8 +638,7 @@ def test_custom_container_spec_config_json():
         assert key not in config_json
 
 def test_HA_RGW_spec():
-    yaml_str =
-"""service_type: HA_RGW
+    yaml_str ="""service_type: HA_RGW
 service_id: haproxy_for_rgw
 placement:
   hosts:
@@ -658,7 +659,7 @@ spec:
 """
     yaml_file = yaml.safe_load(yaml_str)
     spec = ServiceSpec.from_json(yaml_file)
-    assert spec.servie_type == "HA_RGW"
+    assert spec.service_type == "HA_RGW"
     assert spec.service_id == "haproxy_for_rgw"
     assert spec.virtual_ip_interface == "eth0"
     assert spec.virtual_ip_address == "192.168.20.1/24"

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -2,6 +2,7 @@ import logging
 import re
 import json
 import datetime
+import socket
 from enum import Enum
 from functools import wraps
 from typing import Optional, Callable, TypeVar, List, NewType, TYPE_CHECKING
@@ -97,3 +98,7 @@ def str_to_datetime(input: str) -> datetime.datetime:
 
 def datetime_to_str(dt: datetime.datetime) -> str:
     return dt.strftime(DATEFMT)
+
+
+def resolve_ip(hostname: str) -> str:
+    return socket.getaddrinfo(hostname, 2049, flags=socket.AI_CANONNAME, type=socket.SOCK_STREAM)[0][4][0]

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -17,7 +17,7 @@ from mgr_module import MgrModule, HandleCommandResult
 
 from ._interface import OrchestratorClientMixin, DeviceLightLoc, _cli_read_command, \
     raise_if_exception, _cli_write_command, TrivialReadCompletion, OrchestratorError, \
-    NoOrchestrator, OrchestratorValidationError, NFSServiceSpec, \
+    NoOrchestrator, OrchestratorValidationError, NFSServiceSpec, HA_RGWSpec, \
     RGWSpec, InventoryFilter, InventoryHost, HostSpec, CLICommandMeta, \
     ServiceDescription, DaemonDescription, IscsiServiceSpec, json_to_generic_spec, GenericSpec
 
@@ -1190,9 +1190,9 @@ Usage:
 
     @_cli_write_command(
         'orch apply ha_rgw',
-        'Create a High Availability service for existing RGW daemons')
+        desc='Create a High Availability service for existing RGW daemons')
     def _apply_ha_rgw(self,
-                       inbuf: Optional[str] = None) -> HandleCommandResult:
+                      inbuf: Optional[str] = None) -> HandleCommandResult:
 
         usage = """Usage:
   ceph orch apply ha_rgw -i <yaml spec>
@@ -1200,6 +1200,9 @@ Usage:
         if inbuf:
             s = yaml.safe_load(inbuf)
             spec = json_to_generic_spec(s)
+            # make it HA_RGWSpec to make type checker happy and prove
+            # correct spec was made
+            spec = cast(HA_RGWSpec, spec)
         else:
             raise OrchestratorValidationError(usage)
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -381,8 +381,9 @@ class ServiceSpec(object):
     """
     KNOWN_SERVICE_TYPES = 'alertmanager crash grafana iscsi mds mgr mon nfs ' \
                           'node-exporter osd prometheus rbd-mirror rgw ' \
-                          'container'.split()
-    REQUIRES_SERVICE_ID = 'iscsi mds nfs osd rgw container'.split()
+                          'container HA_RGW haproxy keepalived'.split()
+    REQUIRES_SERVICE_ID = 'iscsi mds nfs osd rgw container HA_RGW haproxy ' \
+                          'keepalived'.split()
 
     @classmethod
     def _cls(cls, service_type):
@@ -785,7 +786,7 @@ class HA_RGWSpec(ServiceSpec):
                  service_type: str = 'HA_RGW',
                  service_id: Optional[str] = None,
                  placement: Optional[PlacementSpec] = None,
-                 virtual_ip_interfaces: Optional[str] = None,
+                 virtual_ip_interface: Optional[str] = None,
                  virtual_ip_address: Optional[str] = None,
                  frontend_port: Optional[int] = None,
                  ha_proxy_port: Optional[int] = None,
@@ -800,7 +801,7 @@ class HA_RGWSpec(ServiceSpec):
         super(HA_RGWSpec, self).__init__('HA_RGW', service_id=service_id,
                                                placement=placement)
 
-        self.virtual_ip_interfaces = virtual_ip_interfaces
+        self.virtual_ip_interface = virtual_ip_interface
         self.virtual_ip_address = virtual_ip_address
         self.frontend_port = frontend_port
         self.ha_proxy_port = ha_proxy_port
@@ -815,7 +816,7 @@ class HA_RGWSpec(ServiceSpec):
     def validate(self):
         super(HA_RGWSpec, self).validate()
 
-        if not self.virtual_ip_interfaces:
+        if not self.virtual_ip_interface:
             raise ServiceSpecValidationError(
                 'Cannot add HA_RGW: No Virtual IP Interface specified')
         if not self.virtual_ip_address:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -811,7 +811,10 @@ class HA_RGWSpec(ServiceSpec):
         self.ha_proxy_enable_prometheus_exporter = ha_proxy_enable_prometheus_exporter
         self.ha_proxy_monitor_uri = ha_proxy_monitor_uri
         self.keepalived_password = keepalived_password
-
+        # placeholder variable. Need definitive list of hosts this service will
+        # be placed on in order to generate keepalived config. Will be populated
+        # when applying spec
+        self.definitive_host_list = [] # type: List[HostPlacementSpec]
 
     def validate(self):
         super(HA_RGWSpec, self).validate()


### PR DESCRIPTION
This combined with https://github.com/jmolmo/ceph/pull/5 allowed me to at least get the containers to deploy with the apply ha_rgw command and the spec file https://pastebin.com/Q5V3W52m . 

This still doesn't work entirely. as it doesn't properly set the state for keepalived daemons or provide the ip addresses of other keepalived daemons in the keepalived config file or set the ip & hostnames of servers where RGW daemons are running in the haproxy config file. 

Also, this uses the approach of a single service spec that deploys 2 daemons. It is still up for discussion whether that is a good approach or if we should try to use 2 different service specs (requires syncing the placements).

Lastly, there may be some improvement in what is given for the default container image names and we may want to change the permissions of the keyrings the haproxy and keepalived daemons are getting (right now I'm giving them each a keyring with no caps).