### PR TITLE
support TSL configuration for HAproxy

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/haproxy/haproxy.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/haproxy/haproxy.cfg.j2
@@ -6,6 +6,17 @@ global
     maxconn     8000
     daemon
     stats socket /var/lib/haproxy/stats
+{% if spec.ha_proxy_frontend_ssl_certificate %}
+  {% if spec.ha_proxy_ssl_dh_param %}
+    tune.ssl.default-dh-param {{ spec.ha_proxy_ssl_dh_param }}
+  {% endif %}
+  {% if spec.ha_proxy_ssl_ciphers %}
+    ssl-default-bind-ciphers {{ spec.ha_proxy_ssl_ciphers | join(':') }}
+  {% endif %}
+  {% if spec.ha_proxy_ssl_options %}
+    ssl-default-bind-options {{ spec.ha_proxy_ssl_options | join(' ') }}
+  {% endif %}
+{% endif %}
 
 defaults
     mode                    http
@@ -39,7 +50,11 @@ frontend stats
     monitor-uri {{ spec.ha_proxy_monitor_uri }}
 
 frontend rgw-frontend
+{% if spec.ha_proxy_frontend_ssl_certificate %}
+    bind {{ virtual_ip_address }}:{{ spec.ha_proxy_frontend_ssl_port }} ssl crt {{ spec.ha_proxy_frontend_ssl_certificate }}
+{% else %}
     bind {{ virtual_ip_address }}:{{ spec.frontend_port }}
+{% endif %}
     default_backend rgw-backend
 
 backend rgw-backend

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -796,6 +796,11 @@ class HA_RGWSpec(ServiceSpec):
                  ha_proxy_enable_prometheus_exporter: Optional[bool] = None,
                  ha_proxy_monitor_uri: Optional[str] = None,
                  keepalived_password: Optional[str] = None,
+                 ha_proxy_frontend_ssl_certificate: Optional[str] = None,
+                 ha_proxy_frontend_ssl_port: Optional[int] = None,
+                 ha_proxy_ssl_dh_param: Optional[str] = None,
+                 ha_proxy_ssl_ciphers: Optional[List[str]] = None,
+                 ha_proxy_ssl_options: Optional[List[str]] = None,
                  ):
         assert service_type == 'HA_RGW'
         super(HA_RGWSpec, self).__init__('HA_RGW', service_id=service_id,
@@ -811,6 +816,11 @@ class HA_RGWSpec(ServiceSpec):
         self.ha_proxy_enable_prometheus_exporter = ha_proxy_enable_prometheus_exporter
         self.ha_proxy_monitor_uri = ha_proxy_monitor_uri
         self.keepalived_password = keepalived_password
+        self.ha_proxy_frontend_ssl_certificate = ha_proxy_frontend_ssl_certificate
+        self.ha_proxy_frontend_ssl_port = ha_proxy_frontend_ssl_port
+        self.ha_proxy_ssl_dh_param = ha_proxy_ssl_dh_param
+        self.ha_proxy_ssl_ciphers = ha_proxy_ssl_ciphers
+        self.ha_proxy_ssl_options = ha_proxy_ssl_options
         # placeholder variable. Need definitive list of hosts this service will
         # be placed on in order to generate keepalived config. Will be populated
         # when applying spec
@@ -825,7 +835,7 @@ class HA_RGWSpec(ServiceSpec):
         if not self.virtual_ip_address:
             raise ServiceSpecValidationError(
                 'Cannot add HA_RGW: No Virtual IP Address specified')
-        if not self.frontend_port:
+        if not self.frontend_port and not self.ha_proxy_frontend_ssl_certificate:
             raise ServiceSpecValidationError(
                 'Cannot add HA_RGW: No Frontend Port specified')
         if not self.ha_proxy_port:
@@ -849,6 +859,10 @@ class HA_RGWSpec(ServiceSpec):
         if not self.keepalived_password:
             raise ServiceSpecValidationError(
                 'Cannot add HA_RGW: No Keepalived Password specified')
+        if self.ha_proxy_frontend_ssl_certificate:
+            if not self.ha_proxy_frontend_ssl_port:
+                raise ServiceSpecValidationError(
+                    'Cannot add HA_RGW: Specified Ha Proxy Frontend SSL Certificate but no SSL Port')
 
 
 class CustomContainerSpec(ServiceSpec):


### PR DESCRIPTION
This should roughly provide what we need. Here is an example, showing the spec file provided and the resulting haproxy.cfg: https://pastebin.com/7vbSuUQx

However, I still need some more information to finish this. 

First, in terms of verification, it seems pretty clear that if the user wants to use TSL (which is indicated by them including the ha_proxy_frontend_ssl_certificate in the spec) that they NEED to have the ssl frontend certificate and the ssl frontend port, but I'm not sure if we are supposed to also require the ssl dh param, at least one ssl cipher or at least one ssl option. Right now, I have it requiring something be put for all TSL related fields if the certificate is provided but I'm not sure that's right.

Second, in the example template provided https://raw.githubusercontent.com/ceph/ceph-ansible/master/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2 in the bind  lines of the "frontend rgw-frontend" section the ip provided is just * where as in our templates so far we use a user provided virtual ip address. Should we still use the virtual ip address in the case of TSL or swap to using * in that case?

Lastly, some reasonable sample values for these fields would be helpful for testing. As you can see from my example in the pastebin, I don't have any background knowledge related to this feature and just put sort of random values down.

Signed-off-by: Adam King <adking@redhat.com>