### PR TITLE
warn if prerequisite for deploying haproxy and keepalived not met

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5692,6 +5692,14 @@ def command_gather_facts():
 
 ##################################
 
+def command_verify_prereqs():
+    if args.service_type == 'haproxy' or args.service_type == 'keepalived':
+        out, err, code = call(['sysctl', '-n', 'net.ipv4.ip_nonlocal_bind'])
+        if out.strip() != "1":
+            raise Error('net.ipv4.ip_nonlocal_bind not set to 1')
+
+##################################
+
 
 def _get_parser():
     # type: () -> argparse.ArgumentParser
@@ -6219,6 +6227,15 @@ def _get_parser():
     parser_gather_facts = subparsers.add_parser(
         'gather-facts', help='gather and return host related information (JSON format)')
     parser_gather_facts.set_defaults(func=command_gather_facts)
+
+    parser_verify_prereqs = subparsers.add_parser(
+        'verify-prereqs',
+        help='verify system prerequisites for a given service are met on this host')
+    parser_verify_prereqs.set_defaults(func=command_verify_prereqs)
+    parser_verify_prereqs.add_argument(
+        '--service-type',
+        required=True,
+        help='service type of service to whose prereqs will be checked')
 
     return parser
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1373,7 +1373,7 @@ To check that the host is reachable:
                     sm[n].container_image_name = 'mix'
                 if dd.daemon_type == 'haproxy' or dd.daemon_type == 'keepalived':
                     # HA_RGW has 2 daemons running per host
-                    sm[n].size=sm[n].size*2
+                    sm[n].size = sm[n].size*2
         for n, spec in self.spec_store.specs.items():
             if n in sm:
                 continue
@@ -1392,7 +1392,7 @@ To check that the host is reachable:
                 sm[n].rados_config_location = spec.rados_config_location()
             if spec.service_type == 'HA_RGW':
                 # HA_RGW has 2 daemons running per host
-                sm[n].size=sm[n].size*2
+                sm[n].size = sm[n].size*2
         return list(sm.values())
 
     @trivial_completion

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -803,6 +803,7 @@ class HA_RGWSpec(ServiceSpec):
                  ha_proxy_ssl_options: Optional[List[str]] = None,
                  haproxy_container_image: Optional[str] = None,
                  keepalived_container_image: Optional[str] = None,
+                 definitive_host_list: Optional[List[HostPlacementSpec]] = None
                  ):
         assert service_type == 'HA_RGW'
         super(HA_RGWSpec, self).__init__('HA_RGW', service_id=service_id,


### PR DESCRIPTION
if a prereq is not met, service will fail to deploy and the user
can see the reason by issuing the command

ceph orch ls HA_RGW --format yaml

Signed-off-by: Adam King <adking@redhat.com>

NOTE: will not entirely work until https://github.com/ceph/ceph/pull/38053 is merged
