### PR TITLE
mgr/cephadm: some data integrity validations regarding ha-rgw

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -364,6 +364,7 @@ class HostCache():
         return r
 
     def get_daemon(self, daemon_name: str) -> orchestrator.DaemonDescription:
+        assert not daemon_name.startswith('ha-rgw.')
         for _, dm in self.daemons.items():
             for _, dd in dm.items():
                 if dd.name() == daemon_name:
@@ -383,6 +384,9 @@ class HostCache():
             yield host, {name: alter(host, d) for name, d in dm.items()}
 
     def get_daemons_by_service(self, service_name):
+        assert not service_name.startswith('keepalived.')
+        assert not service_name.startswith('haproxy.')
+
         # type: (str) -> List[orchestrator.DaemonDescription]
         result = []   # type: List[orchestrator.DaemonDescription]
         for host, dm in self.daemons.items():
@@ -392,6 +396,8 @@ class HostCache():
         return result
 
     def get_daemons_by_type(self, service_type):
+        assert service_type not in ['keepalived', 'haproxy']
+
         # type: (str) -> List[orchestrator.DaemonDescription]
         result = []   # type: List[orchestrator.DaemonDescription]
         for host, dm in self.daemons.items():
@@ -507,6 +513,8 @@ class HostCache():
         self.daemons[host][dd.name()] = dd
 
     def rm_daemon(self, host, name):
+        assert not name.startswith('ha-rgw.')
+
         if host in self.daemons:
             if name in self.daemons[host]:
                 del self.daemons[host][name]
@@ -523,6 +531,8 @@ class HostCache():
                    for h in self.get_hosts())
 
     def schedule_daemon_action(self, host: str, daemon_name: str, action: str):
+        assert not daemon_name.startswith('ha-rgw.')
+
         priorities = {
             'start': 1,
             'restart': 2,
@@ -548,6 +558,8 @@ class HostCache():
                 del self.scheduled_daemon_actions[host]
 
     def get_scheduled_daemon_action(self, host, daemon) -> Optional[str]:
+        assert not daemon.startswith('ha-rgw.')
+
         return self.scheduled_daemon_actions.get(host, {}).get(daemon)
 
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1221,6 +1221,8 @@ class DaemonDescription(object):
         # The type of service (osd, mon, mgr, etc.)
         self.daemon_type = daemon_type
 
+        assert daemon_type not in ['HA_RGW', 'ha-rgw']
+
         # The orchestrator will have picked some names for daemons,
         # typically either based on hostnames or on pod names.
         # This is the <foo> in mds.<foo>, the ID that will appear

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -381,9 +381,8 @@ class ServiceSpec(object):
     """
     KNOWN_SERVICE_TYPES = 'alertmanager crash grafana iscsi mds mgr mon nfs ' \
                           'node-exporter osd prometheus rbd-mirror rgw ' \
-                          'container HA_RGW haproxy keepalived'.split()
-    REQUIRES_SERVICE_ID = 'iscsi mds nfs osd rgw container HA_RGW haproxy ' \
-                          'keepalived'.split()
+                          'container HA_RGW'.split()
+    REQUIRES_SERVICE_ID = 'iscsi mds nfs osd rgw container HA_RGW '.split()
 
     @classmethod
     def _cls(cls, service_type):


### PR DESCRIPTION
Cause, if we're persistently saving invalid data, we'll have a lot of trouble fixing things again. 

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
